### PR TITLE
Backend category configuration form, allow HTML according to Joomla usergroup text filters

### DIFF
--- a/custom/category.xml
+++ b/custom/category.xml
@@ -17,7 +17,7 @@
 			<field name="cat_setting_sep" type="separator" hr="false" default="Category Title and Image" description="" level="level1" menu="hide" />
 			<field name="cat_title_override" type="text" default="" label="Title Override" description="Enter a title override for the category" filter="raw" />
 			<field name="cat_title_css" type="text" default="" label="Title CSS" description="Enter css class for the category title" filter="raw" />
-			<field name="cat_teaser_text" type="textarea" default="" label="Teaser Text" description="Custom teaser text." fieldnameasvalue="1" />
+			<field name="cat_teaser_text" type="textarea" filter="JComponentHelper::filterText" default="" label="Teaser Text" description="Custom teaser text." fieldnameasvalue="1" />
 			<field name="cat_teaser_img" type="media" field_type="image" default="" label="Teaser Image" description="Upload an image to use for teasers. Image has a 1:1 aspect ratio and should be at least 300 x 300" fieldnameasvalue="1"/>
 			<field name="cat_img_align" type="radio" default="" label="Image Aligment" description="Select the category image aligment" class="btn-group group-fcinfo">
 				<option value="">None</option>
@@ -305,7 +305,7 @@
 				<option value="1">FLEXI_YES</option>
 			</field>
 			<field name="items_addthis_after" type="fields" field_type="" default="" label="Sharing Buttons After" description="Select the position of AddThis sharing buttons after a field" fieldnameasvalue="1" />
-			<field name="items_addthis_services" type="textarea" filter="raw" default="&lt;a class=&quot;addthis_button_facebook_like&quot; fb:like:layout=&quot;button_count&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_button_tweet&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_counter addthis_pill_style&quot;&gt;&lt;/a&gt;" label="AddThis Services" description="Add the necessary AddThis services (raw HTML)" />
+			<field name="items_addthis_services" type="textarea" filter="JComponentHelper::filterText" default="&lt;a class=&quot;addthis_button_facebook_like&quot; fb:like:layout=&quot;button_count&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_button_tweet&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_counter addthis_pill_style&quot;&gt;&lt;/a&gt;" label="AddThis Services" description="Add the necessary AddThis services (raw HTML)" />
 			<field name="items_disqus" type="radio" default="0" label="Comments Count" description="Show or hide Disqus comments count on individual items." class="btn-group btn-group-yesno">
 				<option value="0">FLEXI_NO</option>
 				<option value="1">FLEXI_YES</option>


### PR DESCRIPTION
Normally layouts configuration is editable by privileged users, still it is best to respect Joomla text-filters
- without this change only string will be allow in v3.1.0 final
