### PR TITLE
Allow input according to Joomla text filters settings for custom addThis code

### DIFF
--- a/custom/item.xml
+++ b/custom/item.xml
@@ -17,7 +17,7 @@
 				<option value="1">FLEXI_YES</option>
 			</field>
 			<field name="items_addthis_after" type="fields" field_type="" default="" label="Sharing Buttons After" description="Select the position of AddThis sharing buttons after a field" fieldnameasvalue="1" />
-			<field name="items_addthis_services" type="textarea" filter="raw" default="&lt;a class=&quot;addthis_button_facebook_like&quot; fb:like:layout=&quot;button_count&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_button_tweet&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_counter addthis_pill_style&quot;&gt;&lt;/a&gt;" label="AddThis Services" description="Add the necessary AddThis services (raw HTML)" />
+			<field name="items_addthis_services" type="textarea" filter="JComponentHelper::filterText" default="&lt;a class=&quot;addthis_button_facebook_like&quot; fb:like:layout=&quot;button_count&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_button_tweet&quot;&gt;&lt;/a&gt;&lt;a class=&quot;addthis_counter addthis_pill_style&quot;&gt;&lt;/a&gt;" label="AddThis Services" description="Add the necessary AddThis services (raw HTML)" />
 			<field name="items_disqus" type="radio" default="0" label="Comments Count" description="Show or hide Disqus comments count on individual items." class="btn-group btn-group-yesno">
 				<option value="0">FLEXI_NO</option>
 				<option value="1">FLEXI_YES</option>


### PR DESCRIPTION
Normally layouts configuration is editable by privileged users, still it is best to respect Joomla text-filters
- still it is best not to use "raw" as filter for this code, and instead use the text-filtering of current user
